### PR TITLE
Merging file upload from client to server into master. 

### DIFF
--- a/Client/Commands.cpp
+++ b/Client/Commands.cpp
@@ -2,11 +2,16 @@
 #include "defines.h"
 #include "logger.h"
 #include "utility.h"
+#include "stream.h"
 
 #include <fstream>
 
 namespace UI {
 	const std::string parseCommand(Shared::Socket& socket, std::vector<std::string>& args) {
+		if (args.size() <= 0) {
+			return "";
+		}
+
 		std::string result;
 		std::string command = args[0];
 		// Remove the first element
@@ -54,69 +59,17 @@ namespace UI {
 	}
 
 	const std::string cmdPush(Shared::Socket& socket, const std::vector<std::string>& args) {
-		const std::string FILE_PATH = Shared::findFilePath(args[0]);
 		std::string result = "";
 
-		// Attempt to open the file 
-		std::ifstream file = std::ifstream(FILE_PATH, std::ios::in);
-		
-		// Ensure the file opens properly
-		if (!file.fail() && !file.bad()) {
-			// Sequence buffer for file data
-			char data[MAX_DATA_SIZE];
+		int streamReturn = Shared::streamOutFileOverSocket(socket, args[0]);
 
-			// Packet to be sent
-			Shared::PacketHeader hdr;
-			hdr.actionID = Shared::ACT_UPLOAD;
-			hdr.pktType = Shared::ACTION;
-			hdr.sequenceNum = 0;
-			Shared::Packet pkt;
-
-			// Send the initial packet with the filename as data
-			hdr.dataSize = args[0].length();
-			pkt.setPacket(hdr, args[0].c_str(), hdr.dataSize);
-
-			if (socket.send(pkt) < 0) {
-				Shared::log("client.log", -1, "Failed to send initial upload packet to server.");
-			}
-			else {
-				Shared::log("client.log", 0, "Sent initial upload packet.");	
-			}
-
-			// Increment sequence to indicate we are starting to send data
-			hdr.sequenceNum++;
-
-			// Send all file data to the server
-			do {
-				// Begin streaming file sequeneces
-				file.read(data, MAX_DATA_SIZE);
-
-				// Query the result
-				uint16_t bytes = static_cast<uint16_t>(file.gcount());
-
-				// Send a sequence packet to the server
-				hdr.dataSize = bytes;
-				pkt.setPacket(hdr, data, bytes);
-				if (socket.send(pkt) < 0) {
-					Shared::log("client.log", -1, "Failed to send upload sequence packet to server.");
-				}
-				else {
-					Shared::log("client.log", 0, "Sent a sequence to the server.");
-				}
-
-				hdr.sequenceNum++;
-
-			} while (false == file.eof() && false == file.fail());
-			
-			// Send final stream packet to the server
-			hdr.dataSize = 0;
-			pkt.setPacket(hdr, nullptr, 0);
-
+		if (streamReturn == 0) {
+			result = "Successfully sent file " + args[0] + " to the server!\n";
 		}
 		else {
-			result = "Error: Could not find file.";
+			result = "Error " + std::to_string(streamReturn) + " when sending sequences.\n";
 		}
-
+		
 		return result;
 	}
 

--- a/Server/Server.vcxproj
+++ b/Server/Server.vcxproj
@@ -132,6 +132,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="serverStream.cpp" />
     <ClCompile Include="server_interface.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -140,6 +141,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="serverStream.h" />
     <ClInclude Include="server_interface.h" />
     <ClInclude Include="states.h" />
   </ItemGroup>

--- a/Server/Server.vcxproj.filters
+++ b/Server/Server.vcxproj.filters
@@ -21,12 +21,18 @@
     <ClCompile Include="server_interface.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="serverStream.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="states.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="server_interface.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="serverStream.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Server/serverStream.cpp
+++ b/Server/serverStream.cpp
@@ -1,0 +1,116 @@
+#include "serverStream.h"
+
+#include "logger.h"
+#include "utility.h"
+
+namespace Server {
+	bool handleUploadPacketOne(Server::State& state, Shared::Packet const& gotPacket, std::string& uploadFilename) {
+		bool error = false;
+
+		if (gotPacket.getPacketHeader().sequenceNum == 0) {
+			state = Server::State::READING;
+			Shared::log("server.log", 0, "Transitioned to the READING state.");
+
+			// Safely copy out the buffer
+			char nameBuffer[200];
+			::memset(nameBuffer, 0, sizeof(nameBuffer));
+			::memcpy(nameBuffer, gotPacket.getData(), (gotPacket.getPacketHeader().dataSize < 200) ? gotPacket.getPacketHeader().dataSize : 199);
+
+			// First packet with filename
+			uploadFilename = "DL-" + std::string(nameBuffer);
+			uploadFilename = Shared::findFilePath(uploadFilename);
+			std::cout << "Preparing file upload for '" << uploadFilename << "'. Waiting for sequences..." << std::endl;
+		}
+		else {
+			Shared::log("server.log", -1, "Server was not in reading state, but sequence was greater than 0. We are missing the new filename.");
+			error = true;
+		}
+
+		return error;
+	}
+
+	bool handleUploadPacketData(Shared::Packet const& gotPacket, std::vector<SequenceContainer>& sequences) {
+		bool error = false;
+		const Shared::PacketHeader& HEADER = gotPacket.getPacketHeader();
+
+		// Resize sequences vector to fit total sequence count
+		if (HEADER.sequenceNum > sequences.size()) {
+			// Resize the vector to fit all values, initialize each index with nullptr
+			sequences.resize(HEADER.sequenceNum, { nullptr, 0 });
+		}
+
+		// Allocate space for the sequence at the correct index. 
+		sequences[HEADER.sequenceNum - 1].dataPtr = new char[HEADER.dataSize];
+		if (sequences[HEADER.sequenceNum - 1].dataPtr == nullptr) {
+			Shared::log("server.log", -1, "Failed to allocate memory for upload sequence.");
+			error = true;
+		}
+		else {
+			// Copy the packet data into the sequence buffer
+			memcpy(sequences[HEADER.sequenceNum - 1].dataPtr, gotPacket.getData(), HEADER.dataSize);
+			// Save the size of the sequence
+			sequences[HEADER.sequenceNum - 1].bytes = HEADER.dataSize;
+		}
+
+		return error;
+	}
+
+	bool handleUploadPacketFinal(Shared::Packet const& gotPacket, std::vector<SequenceContainer>& sequences, Server::State& state, std::string& uploadFilename) {
+		bool error = false;
+
+		// Header.dataSize == 0
+		// This is the final sequence
+		// Make sure all sequences prior to this sequence number are present
+		bool allPresent = true;
+		for (uint16_t i = 0; i < sequences.size(); i++) {
+			if (sequences[i].dataPtr == nullptr) {
+				Shared::log("server.log", i + 1, "Sequence number was missing. Final packet came out of order, or a packet was dropped.");
+				allPresent = false;
+			}
+		}
+
+		// All sequences present, write to file
+		if (allPresent) {
+			// Open file for writing
+			std::ofstream file(uploadFilename, std::ios::out | std::ios::binary);
+			if (file.fail() || file.bad()) {
+				Shared::log("server.log", -1, "Failed to open file for writing.");
+				error = true;
+			}
+			else {
+				for (uint16_t i = 0; i < sequences.size(); i++) {
+					file.write(sequences[i].dataPtr, sequences[i].bytes);
+
+					if (file.fail() || file.bad()) {
+						Shared::log("server.log", -1, "Failed to write to disk. Unexpected error. File went bad.");
+						error = true;
+						break; // Break out of the for loop
+					}
+				}
+
+				Shared::log("server.log", 0, "Done writing file to disk.");
+
+				// Close the file
+				file.close();
+			}
+		}
+		// Sequences were missing. Respond with failure.
+		else {
+			error = true;
+		}
+
+		// Clear the sequences vector
+		for (int i = 0; i < sequences.size(); i++) {
+			// Free up any allocated sequences
+			if (sequences[i].dataPtr != nullptr) {
+				delete[] sequences[i].dataPtr;
+			}
+		}
+		sequences.clear();
+
+		state = Server::State::LISTENING;
+		Shared::log("server.log", 0, "Transitioned to the LISTENING state.");
+
+		return error;
+	}
+}

--- a/Server/serverStream.h
+++ b/Server/serverStream.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "states.h"
+#include "Packet.h"
+
+namespace Server {
+	struct SequenceContainer {
+		char* dataPtr;
+		uint16_t bytes;
+	};
+
+
+	/* @brief Handle the initial packet of an upload stream on the server-side. 
+	*  @param[in/out] state				A reference to the state object that will be overwritten and read
+	*  @param[in] gotPacket				The received packet object
+	*  @param[in/out] uploadFilename	The filename object to store the received filename from this packet
+	*  @return							True upon error. False otherwise.
+	*/
+	extern bool handleUploadPacketOne(Server::State& state, Shared::Packet const& gotPacket, std::string& uploadFilename);
+
+	/* @brief Handle the data packets of an upload stream on the server-side
+	*  @param[in] gotPacket				A reference to the packet object
+	*  @param[in/out] sequences			A references to the sequences vector that contains the list of dynamically allocated sequences.
+	*  @param[out] pktResponse			A reference to the pktResponse value holding the return value 
+	*  @return							True upon error. False otherwise.
+	*/
+	extern bool handleUploadPacketData(Shared::Packet const& gotPacket, std::vector<SequenceContainer>& sequences);
+
+	/*
+	*  @param[in] gotPacket				The received packet object
+	*  @param[in/out] sequences			A references to the sequences vector that contains the list of dynamically allocated sequences.
+	*  @param[in/out] state				A reference to the state object that will be overwritten and read
+	*  @param[in/out] uploadFilename	The filename object to store the received filename from this packet
+	*  @return							True if a sequence was missing, false otherwise. 
+	*/
+	extern bool handleUploadPacketFinal(Shared::Packet const& gotPacket, std::vector<SequenceContainer>& sequences, Server::State& state, std::string& uploadFilename);
+}

--- a/Server/server_interface.h
+++ b/Server/server_interface.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 namespace Server {
 	/*

--- a/Shared/Packet.cpp
+++ b/Shared/Packet.cpp
@@ -109,11 +109,7 @@ namespace Shared {
 
     bool Packet::copyData(const char* buffer, unsigned short int size) {
         // Ensure that the buffer exists
-        if (buffer == nullptr) {
-            std::cerr << "Could not copy packet data. Buffer was null." << std::endl;
-            return true;
-        }
-        else {
+        if (buffer != nullptr) {
 
             // If data is already allocated, free it.
             if (this->data != nullptr) {

--- a/Shared/Packet.h
+++ b/Shared/Packet.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <iostream>
 #include <vector>
 #include <variant>

--- a/Shared/Shared.vcxproj
+++ b/Shared/Shared.vcxproj
@@ -133,12 +133,14 @@
     <ClInclude Include="defines.h" />
     <ClInclude Include="Socket.h" />
     <ClInclude Include="logger.h" />
+    <ClInclude Include="stream.h" />
     <ClInclude Include="utility.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Packet.cpp" />
     <ClCompile Include="Socket.cpp" />
     <ClCompile Include="logger.cpp" />
+    <ClCompile Include="stream.cpp" />
     <ClCompile Include="utility.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Shared/Shared.vcxproj.filters
+++ b/Shared/Shared.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="defines.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="stream.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Packet.cpp">
@@ -42,6 +45,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="utility.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="stream.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Shared/logger.cpp
+++ b/Shared/logger.cpp
@@ -12,7 +12,7 @@ namespace Shared {
 	 * @param filename This parameter is a string variable that contains the name of the file to write to. This is separated from the log folder to ensure client and server have separate files.
 	 * @param successFlag This parameter is a flag that indicates if a packet was sent/received successfully or not.
 	 */
-	void log(std::string filename, int8_t successFlag, std::string msg) {
+	void log(std::string filename, int32_t successFlag, std::string msg) {
 		std::ostringstream stream;
 		stream << std::chrono::system_clock::now().time_since_epoch().count() << ":	" << static_cast<int32_t>(successFlag) << " '" << msg << "'";
 

--- a/Shared/logger.h
+++ b/Shared/logger.h
@@ -4,5 +4,5 @@
 #include <fstream>
 
 namespace Shared {
-	extern void log(std::string filename, int8_t successFlag, std::string msg);
+	extern void log(std::string filename, int32_t successFlag, std::string msg);
 }

--- a/Shared/stream.cpp
+++ b/Shared/stream.cpp
@@ -1,0 +1,86 @@
+#include "stream.h"
+#include "defines.h"
+#include "logger.h"
+#include "utility.h"
+
+#include <fstream>
+
+namespace Shared {
+	int streamOutFileOverSocket(Socket& socket, const std::string& filepath) {
+		const std::string FILE_PATH = Shared::findFilePath(filepath);
+		int result = 0;
+
+		// Attempt to open the file 
+		std::ifstream file = std::ifstream(FILE_PATH, std::ios::in | std::ios::binary);
+
+		// Ensure the file opens properly
+		if (!file.fail() && !file.bad()) {
+			// Sequence buffer for file data
+			char data[MAX_DATA_SIZE];
+
+			// Packet to be sent
+			Shared::PacketHeader hdr;
+			hdr.actionID = Shared::ACT_UPLOAD;
+			hdr.pktType = Shared::ACTION;
+			hdr.sequenceNum = 0;
+			Shared::Packet pkt;
+
+			// Send the initial packet with the filename as data
+			hdr.dataSize = filepath.length();
+			pkt.setPacket(hdr, filepath.c_str(), hdr.dataSize);
+
+			if (socket.send(pkt) < 0) {
+				Shared::log("stream.log", -1, "Failed to send initial upload packet to server.");
+				result = -1;
+			}
+			else {
+				Shared::log("stream.log", 0, "Sent initial upload packet.");
+			}
+
+			// Increment sequence to indicate we are starting to send data
+			hdr.sequenceNum++;
+
+			// Send all file data to the server
+			do {
+				// Begin streaming file sequeneces
+				file.read(data, MAX_DATA_SIZE);
+
+				// Query the result
+				std::uint16_t bytes = static_cast<uint16_t>(file.gcount());
+				//std::cout << "File sequence " << hdr.sequenceNum << " was of size " << bytes << " bytes" << std::endl;
+
+				// Send a sequence packet to the server
+				hdr.dataSize = bytes;
+				pkt.setPacket(hdr, data, bytes);
+				if (socket.send(pkt) < 0) {
+					result = -2;
+					Shared::log("stream.log", result, "Failed to send upload sequence packet to server.");
+				}
+				else {
+					Shared::log("stream.log", hdr.sequenceNum, "Sent a sequence to the server.");
+				}
+
+				hdr.sequenceNum++;
+
+			} while (false == file.eof() && false == file.fail());
+
+			// Send final stream packet to the server
+			hdr.dataSize = 0;
+			pkt.setPacket(hdr, nullptr, 0);
+
+			if (socket.send(pkt) < 0) {
+				result = -3;
+				Shared::log("stream.log", result, "Failed to send final sequence packet to server.");
+			}
+			else {
+				Shared::log("stream.log", 0, "Sent final sequence to the server.");
+			}
+		}
+		else {
+			Shared::log("stream.log", -1, "File failed to open.");
+			result = -1;
+		}
+
+		return result;
+	}
+}

--- a/Shared/stream.cpp
+++ b/Shared/stream.cpp
@@ -57,7 +57,7 @@ namespace Shared {
 					Shared::log("stream.log", result, "Failed to send upload sequence packet to server.");
 				}
 				else {
-					Shared::log("stream.log", hdr.sequenceNum, "Sent a sequence to the server.");
+					Shared::log("stream.log", hdr.dataSize, "Sent a sequence to the server.");
 				}
 
 				hdr.sequenceNum++;
@@ -75,6 +75,9 @@ namespace Shared {
 			else {
 				Shared::log("stream.log", 0, "Sent final sequence to the server.");
 			}
+
+			// Close the file
+			file.close();
 		}
 		else {
 			Shared::log("stream.log", -1, "File failed to open.");

--- a/Shared/stream.h
+++ b/Shared/stream.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "string"
+#include "Socket.h"
+
+namespace Shared {
+	/* @brief Send a file over a socket
+	*  @param[in] socket	A reference to the open socket that the file will be sent over
+	*  @param[in] path		A full static path to the file that will be sent
+	*  @return				A status code. <0 if any packets failed to send. 0 otherwise.
+	*/
+	extern int streamOutFileOverSocket(Socket& socket, const std::string& filepath);
+}

--- a/Shared/utility.cpp
+++ b/Shared/utility.cpp
@@ -67,7 +67,7 @@ namespace Shared {
 		displayFiles(path);
 	}
 
-	extern std::string findFilePath(const std::string& filename) {
+	std::string findFilePath(const std::string& filename) {
 		std::string path = getRootPath();
 		
 		// Check logs dir

--- a/Shared/utility.h
+++ b/Shared/utility.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include "Socket.h"
 
 #define DisplaySentFiles DisplayReceivedFiles
 


### PR DESCRIPTION
This PR implements REQ-CLT-030, REQ-SVR-050, and REQ-SVR-020. 

### REQ-CLT-030
Files can be uploaded from the client to the server. This has been successfully tested using a 6mb file, which is larger than the 5 mb requirement. <br>
Files must be placed within the %AppData%/GoogCraftImages/files/ directory in order to be uploaded. Uploaded/downloaded files are placed in this directory by the receiver. 

### REQ-SVR-050
Large files can be processed by the server. The output is placed within the %AppData%/GoogCraftImages/files/ directory as the filename that was provided during the upload procedure. 

### REQ-SVR-020
The server is capable for writing any filetype provided, as file uploads are expected to occur in binary format. 